### PR TITLE
set nextjs version to latest with react v17 instead of v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "axios": "^0.27.2",
     "browserify-fs": "^1.0.0",
     "ethereum-blockies-base64": "^1.0.2",
-    "next": "canary",
+    "next": "12.1.4",
     "next-images": "^1.8.4",
     "node-polyfill-webpack-plugin": "^2.0.0",
     "react": "^17.0.0",


### PR DESCRIPTION
Fixes problem with nextjs using react v18 and everything else on react v17 which ends up with dual react libraries, creating many many horrible errors.